### PR TITLE
Pull default values from environment for kms encrypt --project and --key flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,11 @@ import (
 	project_map "github.com/dpc-sdp/bay-cli/cmd/project-map"
 )
 
+const (
+	EnvLagoonProject         = "LAGOON_PROJECT"
+	EnvLagoonEnvironmentType = "LAGOON_ENVIRONMENT_TYPE"
+)
+
 func main() {
 	app := &cli.App{
 		Name:  "bay",
@@ -27,11 +32,13 @@ func main() {
 							&cli.StringFlag{
 								Name:     "project",
 								Usage:    "Name of lagoon project",
+								EnvVars:  []string{EnvLagoonProject},
 								Required: true,
 							},
 							&cli.StringFlag{
 								Name:     "key",
 								Usage:    "Name of key",
+								EnvVars:  []string{EnvLagoonEnvironmentType},
 								Required: true,
 							},
 						},


### PR DESCRIPTION
# Motivation

I want the encrypt command to be dead simple for use by devs. This PR makes the --project and --key flags unnecessary in many cases.

If you ssh into a lagoon environment and want to encrypt a value for the current project and environment you can simply run `bay kms encrypt` now.

# Changes

- `bay kms encrypt --project` flag pulls the default value from the environment variable `LAGOON_PROJECT`
- `bay kms encrypt --key` flag pulls the default value from the environment variable `LAGOON_ENVIRONMENT_TYPE`